### PR TITLE
Allow symfony 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+CHANGELOG
+=========
+
+2.0
+---
+
+* Bump PHP version to `>.8.0`
+* Compatibility with Symfony 6 :
+  * Bump `symfony/http-client-contracts` to `^3.0`
+  * Bump `symfony/cache-contracts` to `^3.0`
+

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.4.3",
-        "symfony/cache": "5.2.0",
-        "symfony/http-client": "^5.2",
+        "symfony/cache": "^5.2 || ^6.0",
+        "symfony/http-client": "^5.2 || ^6.0",
         "phpstan/phpstan": "^0.12.64"
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -15,18 +15,18 @@
         "psr-4": {"BenjaminFavre\\OAuthHttpClient\\": "src/"}
     },
     "require": {
-        "php": "^7.2.5 || ^8.0.0",
+        "php": "^8.0.0",
         "ext-json": "*",
-        "symfony/http-client-contracts": "^2.3.1",
-        "symfony/cache-contracts": "^2.2.0"
+        "symfony/http-client-contracts": "^3.0",
+        "symfony/cache-contracts": "^3.0"
     },
     "provide": {
         "symfony/http-client-implementation": "^2.3.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.4.3",
-        "symfony/cache": "^5.2 || ^6.0",
-        "symfony/http-client": "^5.2 || ^6.0",
+        "symfony/cache": "^6.0",
+        "symfony/http-client": "^6.0",
         "phpstan/phpstan": "^0.12.64"
     },
     "scripts": {

--- a/src/OAuthHttpClient.php
+++ b/src/OAuthHttpClient.php
@@ -90,4 +90,9 @@ class OAuthHttpClient implements HttpClientInterface
     {
         return $this->client->stream($responses, $timeout);
     }
+
+    public function withOptions(array $options): static
+    {
+        return new static($this->client->withOptions($options), $this->grant);
+    }
 }


### PR DESCRIPTION
# Abstract

To allow Symfony 6, this lib needs to handle `"symfony/http-client-contracts": "^3.0"`.

Unfortunately, due to changes in the `HttpClientInterface`, this means:
 * PHP 8 minimal
 * Symfony `^6` instead of `^5.0 || ^6.0`.

This means a major bump in this library's number, from `1.0` to `2.0`.

# Details

`symfony/contract` changed  `HttpClient/HttpClientInterface` between `2.5` and `3.0`, adding the `withOptions(array $options): static` method to that interface (see https://github.com/symfony/contracts/commit/87fd917b22354ce0986421e80da3c5f55eef268f).

However, return type of `static` was only introduced in PHP 8.0, where `HttpClient/HttpClientInterface@2.5` allows for PHP 7.4+.

 I don't see a way to correctly implement the `HttpClientInterface`, to handle both `"symfony/http-client-contracts": "^2.5 || ^3.0"` and `"symfony/http-client-contracts": "3.0"` **AND** `"php": "^7.2.5 || ^8.0.0"`. One of those constraints needs to be dropped, meaning a major version bump.