### PR TITLE
Add `headers` option when none is present

### DIFF
--- a/src/RequestSigner/HeaderRequestSigner.php
+++ b/src/RequestSigner/HeaderRequestSigner.php
@@ -18,7 +18,11 @@ class HeaderRequestSigner implements RequestSignerInterface
 
     public function modify(array &$options, string $token): void
     {
-        if (!array_key_exists('headers', $options) || !is_array($options['headers'])) {
+        if (!array_key_exists('headers', $options)) {
+            $options['headers'] = [];
+        }
+
+        if (!is_array($options['headers'])) {
             return;
         }
 


### PR DESCRIPTION
Thanks for a cool little library.

Didn't work for me as it does not sign requests using `BearerHeaderRequestSigner` when the `headers` option is not present, I think it should just add it in that case?