### PR TITLE
Do not distribute psalm an ecs configs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,10 @@
 * text=auto
 
-/.github                        export-ignore
+# Do not include the following files when creating repo artifacts, e.g. the zip
+/.*                             export-ignore
 /tests                          export-ignore
-/.editorconfig                  export-ignore
-/.gitattributes                 export-ignore
-/.gitignore                     export-ignore
+/ecs.php                        export-ignore
 /phpunit.xml.dist               export-ignore
+/psalm.xml                      export-ignore
 /CHANGELOG.md                   export-ignore
 /README.md                      export-ignore


### PR DESCRIPTION
This PR adds ecs.php and psalm.xml configs to .gitattribute in order to not distribute them as well as other configs