### PR TITLE
Add optional `scope` parameter to ClientCredentialsGrantType

### DIFF
--- a/src/GrantType/ClientCredentialsGrantType.php
+++ b/src/GrantType/ClientCredentialsGrantType.php
@@ -22,22 +22,27 @@ class ClientCredentialsGrantType implements GrantTypeInterface
 
     private string $clientSecret;
 
+    private string $scope;
+
     /**
      * @param HttpClientInterface $client A HTTP client to be used to communicate with the OAuth server.
      * @param string $tokenUrl The full URL of the token endpoint of the OAuth server.
      * @param string $clientId The OAuth client ID.
      * @param string $clientSecret The OAuth client secret.
+     * @param string $scope The scope of the access request.
      */
     public function __construct(
         HttpClientInterface $client,
         string $tokenUrl,
         string $clientId,
         string $clientSecret,
+        string $scope = '',
     ) {
         $this->client = $client;
         $this->tokenUrl = $tokenUrl;
         $this->clientId = $clientId;
         $this->clientSecret = $clientSecret;
+        $this->scope = $scope;
     }
 
     /**
@@ -47,9 +52,15 @@ class ClientCredentialsGrantType implements GrantTypeInterface
      */
     public function getTokens(): Tokens
     {
+        $data = ['grant_type' => 'client_credentials'];
+
+        if ($this->scope !== '') {
+            $data['scope'] = $this->scope;
+        }
+
         $response = $this->client->request('POST', $this->tokenUrl, [
             'headers' => ['Authorization' => sprintf('Basic %s', base64_encode("{$this->clientId}:{$this->clientSecret}"))],
-            'body' => http_build_query(['grant_type' => 'client_credentials']),
+            'body' => http_build_query($data),
         ]);
 
         return $this->extractTokens($response);


### PR DESCRIPTION
This PR adds `scope` optional parameter which could used in Oauth Authorization Request. 

RFC: https://www.rfc-editor.org/rfc/rfc6749#section-4.1.1