### PR TITLE
fix return type for getRefreshTokenGrant phpdoc

### DIFF
--- a/src/GrantType/RefreshableGrantTypeInterface.php
+++ b/src/GrantType/RefreshableGrantTypeInterface.php
@@ -14,7 +14,7 @@ interface RefreshableGrantTypeInterface extends GrantTypeInterface
      *
      * @param string $refreshToken An OAuth refresh token acquired by this grant type.
      *
-     * @return RefreshTokenGrantType A refresh grant type built from this grant type.
+     * @return GrantTypeInterface A refresh grant type built from this grant type.
      */
     public function getRefreshTokenGrant(string $refreshToken): GrantTypeInterface;
 }


### PR DESCRIPTION
if someone wants to use a custom refreshable grant type and implement this interface, then the code will fail some validation because the expected return type (inferred from the phpdoc @return) will not pass. I think it would be better to remove this phpdoc @return because the function uses explicit typing system from PHP, however this will fix it too