### PR TITLE
Make OAuth 2 decorator compatible with PHP 8.4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,8 +16,11 @@ jobs:
             matrix:
                 php-version:
                     - "8.0"
+                    - "8.1"
+                    - "8.4"
 
                 dependencies:
+                    - "lowest"
                     - "highest"
 
         steps:
@@ -55,6 +58,7 @@ jobs:
                 php-version:
                     - "8.0"
                     - "8.1"
+                    - "8.4"
 
                 dependencies:
                     - "lowest"
@@ -93,6 +97,7 @@ jobs:
                 php-version:
                     - "8.0"
                     - "8.1"
+                    - "8.4"
 
                 dependencies:
                     - "lowest"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
         strategy:
             matrix:
                 php-version:
-                    - "8.0"
+                    - "8.4"
 
                 dependencies:
                     - "highest"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,11 +16,8 @@ jobs:
             matrix:
                 php-version:
                     - "8.0"
-                    - "8.1"
-                    - "8.4"
 
                 dependencies:
-                    - "lowest"
                     - "highest"
 
         steps:
@@ -56,12 +53,9 @@ jobs:
         strategy:
             matrix:
                 php-version:
-                    - "8.0"
-                    - "8.1"
                     - "8.4"
 
                 dependencies:
-                    - "lowest"
                     - "highest"
 
         steps:
@@ -95,12 +89,9 @@ jobs:
         strategy:
             matrix:
                 php-version:
-                    - "8.0"
-                    - "8.1"
                     - "8.4"
 
                 dependencies:
-                    - "lowest"
                     - "highest"
 
         steps:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "homepage": "https://github.com/BenjaminFavre/oauth2-http-client",
     "require": {
-        "php": "^8.0",
+        "php": "^8.4",
         "ext-json": "*",
         "symfony/cache-contracts": "^3.0",
         "symfony/http-client-contracts": "^3.0"

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "homepage": "https://github.com/BenjaminFavre/oauth2-http-client",
     "require": {
-        "php": "^8.4",
+        "php": "^8.0",
         "ext-json": "*",
         "symfony/cache-contracts": "^3.0",
         "symfony/http-client-contracts": "^3.0"

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "sylius-labs/coding-standard": "^4.2",
         "symfony/cache": "^6.0",
         "symfony/http-client": "^6.0",
-        "vimeo/psalm": "^4.26"
+        "vimeo/psalm": "^6.9.4"
     },
     "provide": {
         "symfony/http-client-implementation": "^2.3.1"

--- a/psalm.xml
+++ b/psalm.xml
@@ -4,7 +4,7 @@
     errorLevel="1"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
-    phpVersion="8.1"
+    phpVersion="8.4"
 >
     <projectFiles>
         <directory name="src"/>

--- a/src/Exception/OAuthException.php
+++ b/src/Exception/OAuthException.php
@@ -8,7 +8,8 @@ use RuntimeException;
 
 /**
  * Represents errors during OAuth protocol.
+ * @psalm-api
  */
-final class OAuthException extends RuntimeException implements OAuthExceptionInterface
+class OAuthException extends RuntimeException implements OAuthExceptionInterface
 {
 }

--- a/src/Exception/OAuthException.php
+++ b/src/Exception/OAuthException.php
@@ -9,6 +9,6 @@ use RuntimeException;
 /**
  * Represents errors during OAuth protocol.
  */
-class OAuthException extends RuntimeException implements OAuthExceptionInterface
+final class OAuthException extends RuntimeException implements OAuthExceptionInterface
 {
 }

--- a/src/GrantType/AuthorizationCodeGrantType.php
+++ b/src/GrantType/AuthorizationCodeGrantType.php
@@ -10,7 +10,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * Implementation of the OAuth authorization grant type.
  */
-class AuthorizationCodeGrantType implements RefreshableGrantTypeInterface
+final class AuthorizationCodeGrantType implements RefreshableGrantTypeInterface
 {
     use TokensExtractor;
 
@@ -50,6 +50,7 @@ class AuthorizationCodeGrantType implements RefreshableGrantTypeInterface
      *
      * @throws TransportExceptionInterface
      */
+    #[\Override]
     public function getTokens(): Tokens
     {
         $response = $this->client->request('POST', $this->tokenUrl, [
@@ -64,6 +65,7 @@ class AuthorizationCodeGrantType implements RefreshableGrantTypeInterface
         return $this->extractTokens($response);
     }
 
+    #[\Override]
     public function getRefreshTokenGrant(string $refreshToken): GrantTypeInterface
     {
         return new RefreshTokenGrantType($this->client, $this->tokenUrl, $refreshToken, $this->clientId, $this->clientSecret);

--- a/src/GrantType/AuthorizationCodeGrantType.php
+++ b/src/GrantType/AuthorizationCodeGrantType.php
@@ -9,6 +9,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * Implementation of the OAuth authorization grant type.
+ * @psalm-api
  */
 final class AuthorizationCodeGrantType implements RefreshableGrantTypeInterface
 {

--- a/src/GrantType/AuthorizationCodeGrantType.php
+++ b/src/GrantType/AuthorizationCodeGrantType.php
@@ -11,7 +11,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  * Implementation of the OAuth authorization grant type.
  * @psalm-api
  */
-final class AuthorizationCodeGrantType implements RefreshableGrantTypeInterface
+class AuthorizationCodeGrantType implements RefreshableGrantTypeInterface
 {
     use TokensExtractor;
 

--- a/src/GrantType/ClientCredentialsGrantType.php
+++ b/src/GrantType/ClientCredentialsGrantType.php
@@ -10,7 +10,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * Implementation of the OAuth client credentials grant type.
  */
-class ClientCredentialsGrantType implements GrantTypeInterface
+final class ClientCredentialsGrantType implements GrantTypeInterface
 {
     use TokensExtractor;
 
@@ -45,6 +45,7 @@ class ClientCredentialsGrantType implements GrantTypeInterface
      *
      * @throws TransportExceptionInterface
      */
+    #[\Override]
     public function getTokens(): Tokens
     {
         $response = $this->client->request('POST', $this->tokenUrl, [

--- a/src/GrantType/ClientCredentialsGrantType.php
+++ b/src/GrantType/ClientCredentialsGrantType.php
@@ -9,6 +9,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * Implementation of the OAuth client credentials grant type.
+ * @psalm-api
  */
 final class ClientCredentialsGrantType implements GrantTypeInterface
 {

--- a/src/GrantType/ClientCredentialsGrantType.php
+++ b/src/GrantType/ClientCredentialsGrantType.php
@@ -11,7 +11,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  * Implementation of the OAuth client credentials grant type.
  * @psalm-api
  */
-final class ClientCredentialsGrantType implements GrantTypeInterface
+class ClientCredentialsGrantType implements GrantTypeInterface
 {
     use TokensExtractor;
 

--- a/src/GrantType/PasswordGrantType.php
+++ b/src/GrantType/PasswordGrantType.php
@@ -9,6 +9,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * Implementation of the OAuth password grant type.
+ * @psalm-api
  */
 final class PasswordGrantType implements GrantTypeInterface
 {

--- a/src/GrantType/PasswordGrantType.php
+++ b/src/GrantType/PasswordGrantType.php
@@ -11,7 +11,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  * Implementation of the OAuth password grant type.
  * @psalm-api
  */
-final class PasswordGrantType implements GrantTypeInterface
+class PasswordGrantType implements GrantTypeInterface
 {
     use TokensExtractor;
 

--- a/src/GrantType/PasswordGrantType.php
+++ b/src/GrantType/PasswordGrantType.php
@@ -55,6 +55,7 @@ final class PasswordGrantType implements GrantTypeInterface
      *
      * @throws TransportExceptionInterface
      */
+    #[\Override]
     public function getTokens(): Tokens
     {
         $parameters = [

--- a/src/GrantType/PasswordGrantType.php
+++ b/src/GrantType/PasswordGrantType.php
@@ -10,7 +10,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * Implementation of the OAuth password grant type.
  */
-class PasswordGrantType implements GrantTypeInterface
+final class PasswordGrantType implements GrantTypeInterface
 {
     use TokensExtractor;
 

--- a/src/GrantType/RefreshTokenGrantType.php
+++ b/src/GrantType/RefreshTokenGrantType.php
@@ -10,7 +10,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * Implementation of the OAuth refresh token grant type.
  */
-class RefreshTokenGrantType implements GrantTypeInterface
+final class RefreshTokenGrantType implements GrantTypeInterface
 {
     use TokensExtractor;
 
@@ -50,6 +50,7 @@ class RefreshTokenGrantType implements GrantTypeInterface
      *
      * @throws TransportExceptionInterface
      */
+    #[\Override]
     public function getTokens(): Tokens
     {
         $response = $this->client->request('POST', $this->tokenUrl, [

--- a/src/GrantType/RefreshTokenGrantType.php
+++ b/src/GrantType/RefreshTokenGrantType.php
@@ -9,8 +9,9 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * Implementation of the OAuth refresh token grant type.
+ * @psalm-api
  */
-final class RefreshTokenGrantType implements GrantTypeInterface
+class RefreshTokenGrantType implements GrantTypeInterface
 {
     use TokensExtractor;
 

--- a/src/GrantType/Tokens.php
+++ b/src/GrantType/Tokens.php
@@ -6,8 +6,9 @@ namespace BenjaminFavre\OAuthHttpClient\GrantType;
 
 /**
  * Value object for an access token and a refresh token.
+ * @psalm-api
  */
-final class Tokens
+class Tokens
 {
     private string $accessToken;
 

--- a/src/GrantType/Tokens.php
+++ b/src/GrantType/Tokens.php
@@ -7,7 +7,7 @@ namespace BenjaminFavre\OAuthHttpClient\GrantType;
 /**
  * Value object for an access token and a refresh token.
  */
-class Tokens
+final class Tokens
 {
     private string $accessToken;
 

--- a/src/OAuthHttpClient.php
+++ b/src/OAuthHttpClient.php
@@ -84,7 +84,7 @@ final class OAuthHttpClient implements HttpClientInterface
         throw new RuntimeException();
     }
 
-    public function stream($responses, float $timeout = null): ResponseStreamInterface
+    public function stream($responses, ?float $timeout = null): ResponseStreamInterface
     {
         return $this->client->stream($responses, $timeout);
     }

--- a/src/OAuthHttpClient.php
+++ b/src/OAuthHttpClient.php
@@ -40,6 +40,9 @@ final class OAuthHttpClient implements HttpClientInterface
         $this->cache = new MemoryTokensCache();
     }
 
+    /**
+     * @psalm-api
+     */
     public function setSigner(RequestSignerInterface $signer): self
     {
         $this->signer = $signer;
@@ -47,6 +50,9 @@ final class OAuthHttpClient implements HttpClientInterface
         return $this;
     }
 
+    /**
+     * @psalm-api
+     */
     public function setChecker(ResponseCheckerInterface $checker): self
     {
         $this->checker = $checker;
@@ -54,6 +60,9 @@ final class OAuthHttpClient implements HttpClientInterface
         return $this;
     }
 
+    /**
+     * @psalm-api
+     */
     public function setCache(TokensCacheInterface $cache): self
     {
         $this->cache = $cache;
@@ -61,6 +70,7 @@ final class OAuthHttpClient implements HttpClientInterface
         return $this;
     }
 
+    #[\Override]
     public function request(string $method, string $url, array $options = []): ResponseInterface
     {
         $grant = $this->grant;
@@ -84,11 +94,13 @@ final class OAuthHttpClient implements HttpClientInterface
         throw new RuntimeException();
     }
 
+    #[\Override]
     public function stream($responses, ?float $timeout = null): ResponseStreamInterface
     {
         return $this->client->stream($responses, $timeout);
     }
 
+    #[\Override]
     public function withOptions(array $options): static
     {
         return new self($this->client->withOptions($options), $this->grant);

--- a/src/RequestSigner/BearerHeaderRequestSigner.php
+++ b/src/RequestSigner/BearerHeaderRequestSigner.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace BenjaminFavre\OAuthHttpClient\RequestSigner;
 
-class BearerHeaderRequestSigner extends HeaderRequestSigner
+final class BearerHeaderRequestSigner extends HeaderRequestSigner
 {
     public function __construct()
     {

--- a/src/RequestSigner/BearerHeaderRequestSigner.php
+++ b/src/RequestSigner/BearerHeaderRequestSigner.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace BenjaminFavre\OAuthHttpClient\RequestSigner;
 
-final class BearerHeaderRequestSigner extends HeaderRequestSigner
+/**
+ * @psalm-api
+ */
+class BearerHeaderRequestSigner extends HeaderRequestSigner
 {
     public function __construct()
     {

--- a/src/RequestSigner/HeaderRequestSigner.php
+++ b/src/RequestSigner/HeaderRequestSigner.php
@@ -16,6 +16,7 @@ class HeaderRequestSigner implements RequestSignerInterface
         $this->headerValueFormat = $headerValueFormat;
     }
 
+    #[\Override]
     public function modify(array &$options, string $token): void
     {
         if (!array_key_exists('headers', $options)) {

--- a/src/ResponseChecker/StatusCode401ResponseChecker.php
+++ b/src/ResponseChecker/StatusCode401ResponseChecker.php
@@ -6,8 +6,9 @@ namespace BenjaminFavre\OAuthHttpClient\ResponseChecker;
 
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
-class StatusCode401ResponseChecker implements ResponseCheckerInterface
+final class StatusCode401ResponseChecker implements ResponseCheckerInterface
 {
+    #[\Override]
     public function hasAuthenticationFailed(ResponseInterface $response): bool
     {
         return $response->getStatusCode() === 401;

--- a/src/ResponseChecker/StatusCode401ResponseChecker.php
+++ b/src/ResponseChecker/StatusCode401ResponseChecker.php
@@ -6,7 +6,10 @@ namespace BenjaminFavre\OAuthHttpClient\ResponseChecker;
 
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
-final class StatusCode401ResponseChecker implements ResponseCheckerInterface
+/**
+ * @psalm-api
+ */
+class StatusCode401ResponseChecker implements ResponseCheckerInterface
 {
     #[\Override]
     public function hasAuthenticationFailed(ResponseInterface $response): bool

--- a/src/TokensCache/MemoryTokensCache.php
+++ b/src/TokensCache/MemoryTokensCache.php
@@ -7,7 +7,10 @@ namespace BenjaminFavre\OAuthHttpClient\TokensCache;
 use BenjaminFavre\OAuthHttpClient\GrantType\GrantTypeInterface;
 use BenjaminFavre\OAuthHttpClient\GrantType\Tokens;
 
-final class MemoryTokensCache implements TokensCacheInterface
+/**
+ * @psalm-api
+ */
+class MemoryTokensCache implements TokensCacheInterface
 {
     private ?Tokens $tokens = null;
 

--- a/src/TokensCache/MemoryTokensCache.php
+++ b/src/TokensCache/MemoryTokensCache.php
@@ -7,10 +7,11 @@ namespace BenjaminFavre\OAuthHttpClient\TokensCache;
 use BenjaminFavre\OAuthHttpClient\GrantType\GrantTypeInterface;
 use BenjaminFavre\OAuthHttpClient\GrantType\Tokens;
 
-class MemoryTokensCache implements TokensCacheInterface
+final class MemoryTokensCache implements TokensCacheInterface
 {
     private ?Tokens $tokens = null;
 
+    #[\Override]
     public function get(GrantTypeInterface $grant): Tokens
     {
         if ($this->tokens === null) {
@@ -20,6 +21,7 @@ class MemoryTokensCache implements TokensCacheInterface
         return $this->tokens;
     }
 
+    #[\Override]
     public function clear(): void
     {
         $this->tokens = null;

--- a/src/TokensCache/SymfonyTokensCacheAdapter.php
+++ b/src/TokensCache/SymfonyTokensCacheAdapter.php
@@ -9,7 +9,10 @@ use BenjaminFavre\OAuthHttpClient\GrantType\Tokens;
 use RuntimeException;
 use Symfony\Contracts\Cache\CacheInterface;
 
-class SymfonyTokensCacheAdapter implements TokensCacheInterface
+/**
+ * @psalm-api
+ */
+final class SymfonyTokensCacheAdapter implements TokensCacheInterface
 {
     private CacheInterface $cache;
 
@@ -21,6 +24,7 @@ class SymfonyTokensCacheAdapter implements TokensCacheInterface
         $this->cacheKey = $cacheKey;
     }
 
+    #[\Override]
     public function get(GrantTypeInterface $grant): Tokens
     {
         $tokens = $this->cache->get($this->cacheKey, function () use ($grant) {
@@ -34,6 +38,7 @@ class SymfonyTokensCacheAdapter implements TokensCacheInterface
         return $tokens;
     }
 
+    #[\Override]
     public function clear(): void
     {
         $this->cache->delete($this->cacheKey);

--- a/src/TokensCache/SymfonyTokensCacheAdapter.php
+++ b/src/TokensCache/SymfonyTokensCacheAdapter.php
@@ -12,7 +12,7 @@ use Symfony\Contracts\Cache\CacheInterface;
 /**
  * @psalm-api
  */
-final class SymfonyTokensCacheAdapter implements TokensCacheInterface
+class SymfonyTokensCacheAdapter implements TokensCacheInterface
 {
     private CacheInterface $cache;
 


### PR DESCRIPTION
Fix PHP 8.4 deprecation: Implicitly marking parameter as nullable is deprecated, the explicit nullable type must be used instead