### PR TITLE
fix: support public clients in PasswordGrandType

### DIFF
--- a/src/GrantType/PasswordGrantType.php
+++ b/src/GrantType/PasswordGrantType.php
@@ -65,9 +65,14 @@ class PasswordGrantType implements GrantTypeInterface
             'password' => $this->password,
         ];
 
-        if ($this->clientId !== null && $this->clientSecret !== null) {
+        if ($this->clientId !== null) {
             $parameters = array_merge($parameters, [
                 'client_id' => $this->clientId,
+            ]);
+        }
+
+        if ($this->clientId !== null && $this->clientSecret !== null) {
+            $parameters = array_merge($parameters, [
                 'client_secret' => $this->clientSecret,
             ]);
         }


### PR DESCRIPTION
## Allow `client_id` without `client_secret` in PasswordGrantType (RFC 6749 compliance)

## Context

This PR fixes the `PasswordGrantType` implementation to allow sending a `client_id` without requiring a `client_secret`.

Currently, client credentials are only added if **both** `$clientId` and `$clientSecret` are provided:

```php
if ($this->clientId !== null && $this->clientSecret !== null) {
    $parameters = array_merge($parameters, [
        'client_id' => $this->clientId,
        'client_secret' => $this->clientSecret,
    ]);
}
```

This prevents using the password grant with **public clients**, where:

- `client_id` is required
- `client_secret` is not issued

---

## Why This Is Incorrect According to the RFC

According to **RFC 6749 (OAuth 2.0 Authorization Framework)**:

> "A client MAY use the "client_id" request parameter to identify itself
   when sending requests to the token endpoint."

See https://datatracker.ietf.org/doc/html/rfc6749#section-3.2.1

---

## Summary

This PR aligns `PasswordGrantType` with RFC 6749 by:

- Supporting public clients
- Removing unintended enforcement of `client_secret`
- Preserving existing behavior for confidential clients